### PR TITLE
Change HDD to DISK

### DIFF
--- a/conky_rings/.conkyrc
+++ b/conky_rings/.conkyrc
@@ -65,7 +65,7 @@ ${#00FF00}${goto 230}${top name 2}${alignr 84}${top cpu 2}%
 ${#00DD00}${goto 230}${top name 3}${alignr 80}${top cpu 3}%
 ${#00BB00}${goto 230}${top name 4}${alignr 81}${top cpu 4}%
 ${#008800}${goto 230}${top name 5}${alignr 88}${top cpu 5}%
-# HDD
+# DISK
 ${#FF2020}${voffset 42}${alignr 230}${fs_used /home} / ${fs_size /home} root
 ${#FF2020}${voffset 2}${alignr 230}${fs_used /boot} / ${fs_size /boot} boot
 # MEMORY

--- a/conkyrc
+++ b/conkyrc
@@ -74,7 +74,7 @@ $membar
 $font${color #66FFFF}SWAP $alignc ${color #FFFFFF}$swap${color #66FFFF} / $swapmax $alignr $swapperc%
 $swapbar
 
-${font Arial:bold:size=10}${color #00AAFF}HDD ${color #0000AA}${hr 2}
+${font Arial:bold:size=10}${color #00AAFF}DISK ${color #0000AA}${hr 2}
 $font${color #66FFFF}/home $alignc ${color #FFFFFF}${fs_used /home} / ${fs_size /home}${color #66FFFF} $alignr ${fs_free_perc /home}%
 ${fs_bar /home}
 


### PR DESCRIPTION
If you know anything about computer systems you will know HDD stands for hard disk drive, and I'd imagine pretty much every Raspberry Pi has a MicroSD card which is solid state rather than a hard disk, so I have changed it from saying HDD to DISK in the main Conky script and also in the Rings but it didn't actually say HDD anywhere - there was only a comment. You could also change it to STORAGE but I thought DISK was cleaner.  If there's anywhere else needing to change from hdd to disk just let me know or do it yourself. On a completely different note, can you share a link to the background you use in the conky_screenshot.png image in the readme md because it looks fire 🔥